### PR TITLE
Add CDN images rights ansible task

### DIFF
--- a/ansible/roles/cdn.geotribu.fr/tasks/main.yml
+++ b/ansible/roles/cdn.geotribu.fr/tasks/main.yml
@@ -150,3 +150,14 @@
     provider: selfsigned
   become: true
   when: not letsencrypt_enabled | default(false)
+
+- name: Ajouter les droits sur les images fournies par le CDN
+  tags:
+    - cdn
+    - cdn-post
+  become: true
+  ansible.builtin.file:
+    path: "/var/www/{{ geotribu_www }}/{{ cdn_subdomain }}/images/"
+    owner: geotribu
+    group: www-data
+    mode: "0775"


### PR DESCRIPTION
Ajout de la tâche pour donner les droits aux images.

- doute sur le user, si `geotribu` ou pas plutôt `www-data` soit celui d'apache il me semble.

Avec un tag car le role est censé être lancé une fois les fichiers rétablis.